### PR TITLE
Remove header icon backgrounds and reset sizing

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -2508,11 +2508,35 @@ input[type='checkbox'] {
   grid-area: icons;
   justify-self: end;
   padding-right: 0.8rem;
+  background: transparent;
+  background-image: none;
+  box-shadow: none;
+  border: 0;
+  filter: none;
+  backdrop-filter: none;
+}
+
+.header__icons::before,
+.header__icons::after {
+  content: none;
+  display: none;
+}
+
+.header__icons > * {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
 }
 
 .header__icons .shopify-app-block {
-  max-width: 4.4rem;
-  max-height: 4.4rem;
+  max-width: 40px;
+  max-height: 40px;
   overflow: hidden;
 }
 
@@ -2525,6 +2549,13 @@ input[type='checkbox'] {
 
 .header__icon {
   color: rgb(var(--color-foreground));
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
 }
 
 .header__icon span {
@@ -2532,8 +2563,8 @@ input[type='checkbox'] {
 }
 
 .header__icon .svg-wrapper {
-  width: 44px;
-  height: 44px;
+  width: 40px;
+  height: 40px;
 }
 
 .header__icon::after {
@@ -2546,17 +2577,10 @@ input[type='checkbox'] {
 }
 
 .header__icon .icon {
-  height: 2rem;
-  width: 2rem;
+  height: 20px;
+  width: 20px;
   fill: none;
   vertical-align: middle;
-}
-
-.header__icon,
-.header__icon--cart .icon {
-  height: 4.4rem;
-  width: 4.4rem;
-  padding: 0;
 }
 
 .header__icon--cart {


### PR DESCRIPTION
## Summary
- remove background, border, blur, and shadow styling from the header icon wrapper and pseudo-elements
- enforce consistent transparent 40px circular sizing for header icons and embedded app blocks
- reduce icon SVG dimensions to 20px for compact presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e290ec07a8832bb9e4c0917c450e1a